### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: pdf_to_json linters.yml
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/Rushi-Balapure/pdf_to_json/security/code-scanning/2](https://github.com/Rushi-Balapure/pdf_to_json/security/code-scanning/2)

The best way to fix this problem is to explicitly set the `permissions` block at the workflow or job level to the minimum required. Since this is a linting workflow (named `pdf_to_json linters.yml`) and does not appear to require any write access but only source code in the repository, the minimal permission (`contents: read`) can be set. This can be added either globally (at the root of the YAML) or specifically to the `ruff` job. The most conservative, broadly-applicable approach is to add it at the root level, which ensures all jobs get limited permissions unless overridden.

- **How to fix in general:** Add `permissions: contents: read` at the root of the workflow YAML (before `jobs:`).
- **Where to change:** Insert the `permissions:` block after the workflow `name` and before `on`.
- **Requirements:** No library imports or extra methods needed; just an edit to the YAML header.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
