### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,4 +1,6 @@
 name: Pytest
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/Rushi-Balapure/pdf_to_json/security/code-scanning/1](https://github.com/Rushi-Balapure/pdf_to_json/security/code-scanning/1)

To fix the problem, explicitly add a `permissions` block to the workflow file. The single best way to apply least privilege in this case is to place the block at the top level of the workflow YAML, ensuring it applies to all jobs (in this case, only `test`). The minimal required permission is typically `contents: read`, allowing actions to clone the repository and access the code. This block should be inserted immediately following the workflow `name`, before the `on` trigger.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
