### PR TITLE
fix: duplicate permission for Pytest CI run

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,6 +1,4 @@
 name: Pytest
-permissions:
-  contents: read
 
 on:
   push:


### PR DESCRIPTION
fix duplicates in the tests file