### PR TITLE
fix(extractor): add OCR fallback for image-only PDFs

### DIFF
--- a/pdf_2_json_extractor/extractor.py
+++ b/pdf_2_json_extractor/extractor.py
@@ -89,37 +89,49 @@ class PDFStructureExtractor:
         """Yield lines with their concatenated text, max font size, and y-position bounds."""
         for page_num in range(len(doc)):
             blocks = doc[page_num].get_text("dict").get("blocks", [])
-            for block in blocks:
-                lines = block.get("lines")
-                if not lines:
-                    continue
-                for line in lines:
-                    text_parts: list[str] = []
-                    max_size = 0.0
-                    top_y = None
-                    bottom_y = None
-                    for span in line.get("spans", []):
-                        text = span.get("text", "")
-                        if not text or not text.strip():
-                            continue
-                        text_parts.append(text)
-                        size = float(span.get("size", 0.0))
-                        if size > max_size:
-                            max_size = size
-                        bbox = span.get("bbox")
-                        if bbox:
-                            span_top, span_bottom = bbox[1], bbox[3]
-                            top_y = span_top if top_y is None else min(top_y, span_top)
-                            bottom_y = span_bottom if bottom_y is None else max(bottom_y, span_bottom)
-                    if not text_parts:
+            yield from self._iter_lines_from_blocks(page_num, blocks)
+
+    def _iter_lines_from_blocks(self, page_num: int, blocks: list[dict[str, Any]]):
+        """Yield normalized line items from block dictionaries."""
+        for block in blocks:
+            lines = block.get("lines")
+            if not lines:
+                continue
+            for line in lines:
+                text_parts: list[str] = []
+                max_size = 0.0
+                top_y = None
+                bottom_y = None
+                for span in line.get("spans", []):
+                    text = span.get("text", "")
+                    if not text or not text.strip():
                         continue
-                    yield {
-                        "page": page_num,
-                        "text": "".join(text_parts).strip(),
-                        "font_size": round(max_size, 1),
-                        "top": top_y,
-                        "bottom": bottom_y,
-                    }
+                    text_parts.append(text)
+                    size = float(span.get("size", 0.0))
+                    if size > max_size:
+                        max_size = size
+                    bbox = span.get("bbox")
+                    if bbox:
+                        span_top, span_bottom = bbox[1], bbox[3]
+                        top_y = span_top if top_y is None else min(top_y, span_top)
+                        bottom_y = span_bottom if bottom_y is None else max(bottom_y, span_bottom)
+                if not text_parts:
+                    continue
+                yield {
+                    "page": page_num,
+                    "text": "".join(text_parts).strip(),
+                    "font_size": round(max_size, 1),
+                    "top": top_y,
+                    "bottom": bottom_y,
+                }
+
+    def _iter_lines_ocr(self, doc: fitz.Document):
+        """Yield lines from OCR for pages that have no text layer."""
+        for page_num in range(len(doc)):
+            page = doc[page_num]
+            textpage = page.get_textpage_ocr(language="eng")
+            blocks = page.get_text("dict", textpage=textpage).get("blocks", [])
+            yield from self._iter_lines_from_blocks(page_num, blocks)
 
     def _classify_level(self, line_font_size: float, heading_levels: dict[float, str]) -> str | None:
         """Return heading level like 'H1'..'H6' if font size matches, else None."""
@@ -196,6 +208,8 @@ class PDFStructureExtractor:
 
             # Collect all non-empty lines first with layout info
             all_lines: list[dict[str, Any]] = list(self._iter_lines(doc))
+            if not all_lines:
+                all_lines = list(self._iter_lines_ocr(doc))
 
             # Split by headings and group non-heading lines into paragraphs per section
             buffer_non_heading: list[dict[str, Any]] = []

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,8 +3,10 @@ Pytest configuration and fixtures for pdf_2_json_extractor tests.
 """
 
 import os
+import shutil
 from pathlib import Path
 
+import pymupdf as fitz
 import pytest
 
 
@@ -35,6 +37,34 @@ def real_pdf_path(papers_dir: Path) -> Path:
     if not pdf_path.exists():
         pytest.skip(f"Test PDF not found at {pdf_path}")
     return pdf_path
+
+
+@pytest.fixture
+def scanned_pdf_path(tmp_path: Path) -> Path:
+    """Create a scanned-like PDF page (image only, no text layer)."""
+    if shutil.which("tesseract") is None:
+        pytest.skip("tesseract is required for OCR fallback tests")
+
+    source_pdf = tmp_path / "source_text.pdf"
+    scanned_pdf = tmp_path / "scanned_like.pdf"
+
+    doc = fitz.open()
+    page = doc.new_page()
+    page.insert_text((72, 72), "Scanned OCR Test Heading", fontsize=24)
+    page.insert_text((72, 120), "This is body text for OCR fallback.", fontsize=12)
+    doc.save(str(source_pdf))
+    doc.close()
+
+    with fitz.open(str(source_pdf)) as src:
+        pix = src[0].get_pixmap(matrix=fitz.Matrix(2, 2))
+
+    out = fitz.open()
+    image_page = out.new_page(width=pix.width, height=pix.height)
+    image_page.insert_image(image_page.rect, stream=pix.tobytes("png"))
+    out.save(str(scanned_pdf))
+    out.close()
+
+    return scanned_pdf
 
 
 @pytest.fixture

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -70,6 +70,19 @@ class TestExtractTextWithStructure:
             extractor.extract_text_with_structure(str(empty_file_pdf_path))
 
 
+class TestOCRFallback:
+    """Test OCR fallback behavior for scanned PDFs."""
+
+    def test_uses_ocr_for_scanned_pdf(self, scanned_pdf_path: Path):
+        """Scanned image-only PDFs should still produce extracted content."""
+        extractor = PDFStructureExtractor()
+
+        result = extractor.extract_text_with_structure(str(scanned_pdf_path))
+
+        assert result["stats"]["num_paragraphs"] > 0
+        assert len(result["sections"]) > 0
+
+
 class TestFontAnalysis:
     """Test font size analysis on real documents."""
 


### PR DESCRIPTION
## Summary
- Add OCR fallback for scanned/image-only PDFs when native text-layer extraction returns no lines.
- Add a regression test that reproduces the bug using a generated scanned-like PDF fixture.
- Refactor line parsing to reuse a shared normalization path for both native and OCR extraction.
## Problem
The extractor only read embedded PDF text (`get_text("dict")`).  
For scanned PDFs (image-only pages), this returned no content, resulting in empty `sections` and `num_paragraphs = 0`.
## What Changed
- **tests/conftest.py**
  - Added `scanned_pdf_path` fixture:
    - creates a normal PDF with text,
    - renders it to an image,
    - embeds that image into a new PDF (no text layer).
  - Skips OCR test if `tesseract` is unavailable.
- **tests/test_extractor.py**
  - Added `TestOCRFallback::test_uses_ocr_for_scanned_pdf`.
  - Verifies scanned image-only PDFs now produce non-empty extracted content.
- **pdf_2_json_extractor/extractor.py**
  - Added `_iter_lines_from_blocks(...)` helper for shared block-to-line normalization.
  - Added `_iter_lines_ocr(...)` using `page.get_textpage_ocr(language="eng")`.
  - In `extract_text_with_structure(...)`, if native extraction yields no lines, fallback to OCR line extraction.
## Validation
- Ran targeted test (Red -> Green):  
  `python -m pytest tests/test_extractor.py -v`
- Ran full suite:  
  `pytest`
- Result: all tests passing (`36 passed`).
## Notes
- OCR language is currently set to `eng` in this change.
- This PR focuses on reliable content extraction for scanned PDFs; heading quality improvements for OCR output can be handled in a follow-up.
If you want, I can also generate a shorter “maintainer-style” version (2-3 bullets only).